### PR TITLE
Update GitHub workflows and Dockerfile dependencies

### DIFF
--- a/.github/workflows/publish_docker_3key.yaml
+++ b/.github/workflows/publish_docker_3key.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -78,7 +78,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/publish_docker_3key.yaml
+++ b/.github/workflows/publish_docker_3key.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -78,7 +78,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/publish_docker_3key.yaml
+++ b/.github/workflows/publish_docker_3key.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.8.1
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -64,7 +64,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -78,7 +78,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/publish_docker_czertainly.yaml
+++ b/.github/workflows/publish_docker_czertainly.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -78,7 +78,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/publish_docker_czertainly.yaml
+++ b/.github/workflows/publish_docker_czertainly.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -78,7 +78,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/publish_docker_czertainly.yaml
+++ b/.github/workflows/publish_docker_czertainly.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.8.1
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -64,7 +64,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -78,7 +78,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/publish_harbor_3key.yaml
+++ b/.github/workflows/publish_harbor_3key.yaml
@@ -65,7 +65,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -79,7 +79,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/publish_harbor_3key.yaml
+++ b/.github/workflows/publish_harbor_3key.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.8.1
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -65,7 +65,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -79,7 +79,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/publish_harbor_3key.yaml
+++ b/.github/workflows/publish_harbor_3key.yaml
@@ -65,7 +65,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -79,7 +79,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/test_docker_image.yaml
+++ b/.github/workflows/test_docker_image.yaml
@@ -52,7 +52,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -66,7 +66,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/test_docker_image.yaml
+++ b/.github/workflows/test_docker_image.yaml
@@ -52,7 +52,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -66,7 +66,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/.github/workflows/test_docker_image.yaml
+++ b/.github/workflows/test_docker_image.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -52,7 +52,7 @@ jobs:
           echo "value=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           format: json
@@ -66,7 +66,7 @@ jobs:
           path: trivy-report.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ steps.tag.outputs.value }}
           trivy-config: config/trivy.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
-FROM nginx:1.28.0-alpine AS build
+# Add build args to allow easy version updates
+ARG NGINX_BUILD_IMAGE=nginx:1.29.2-alpine
+ARG NGINX_RUN_IMAGE=nginxinc/nginx-unprivileged:1.29.2-alpine
 
+FROM ${NGINX_BUILD_IMAGE} AS build
+
+ARG OPA_VERSION=1.9.0
 LABEL org.opencontainers.image.authors="CZERTAINLY <support@czertainly.com>"
 
 COPY ./policies /usr/share/nginx/html/bundles/policies
 
 WORKDIR /usr/share/nginx/html/bundles
 
-ADD https://openpolicyagent.org/downloads/v1.5.1/opa_linux_amd64_static ./opa
+ADD https://openpolicyagent.org/downloads/v${OPA_VERSION}/opa_linux_amd64_static ./opa
 RUN chmod 755 ./opa && ./opa build -b policies
 RUN rm -r policies && rm opa
 
 # package to rootless image
-FROM nginxinc/nginx-unprivileged:1.28.0-alpine
+FROM ${NGINX_RUN_IMAGE}
 
 COPY --from=build /usr/share/nginx/html /usr/share/nginx/html


### PR DESCRIPTION
- bump GitHub Actions versions for checkout, Cosign, and Trivy
- refactor Dockerfile to use build arguments for NGINX and OPA versions
- update to nginx 1.29.2-alpine and OPA 1.9.0